### PR TITLE
Remove unnecessary check for BigDecimal

### DIFF
--- a/lib/fast_excel.rb
+++ b/lib/fast_excel.rb
@@ -391,8 +391,6 @@ module FastExcel
 
       if value.is_a?(Numeric)
         write_number(row_number, cell_number, value, format)
-      elsif defined?(BigDecimal) && value.is_a?(BigDecimal)
-        write_number(row_number, cell_number, value.to_f, format)
       elsif defined?(DateTime) && value.is_a?(DateTime)
         write_datetime(row_number, cell_number, FastExcel.lxw_datetime(value), format)
       elsif value.is_a?(Time)


### PR DESCRIPTION
```ruby
2.4.1 :024 > bd = BigDecimal.new("2141412412412412412498239058320985902385902385092385092835235235")
 => 0.2141412412412412412498239058320985902385902385092385092835235235e64 
2.4.1 :025 > bd.is_a?(Numeric)
 => true
```
The check for `BigDecimal` is unnecessary, and `write_number` works well on `BigDecimal` (no conversion to float needed).