### PR TITLE
Allow Date along with DateTime in write_value

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ worksheet.write_row(1001, ["Sum", FastExcel::Formula.new("SUM(B2:B1001)")], bold
 workbook.close
 ```
 
-This repositiry and gem contain sources of [libxlsxwriter](https://github.com/jmcnamara/libxlsxwriter)
+This repository and gem contain sources of [libxlsxwriter](https://github.com/jmcnamara/libxlsxwriter)
 
 ## Benchmarks
 
@@ -83,7 +83,7 @@ Full libxlsxwriter documentation: [http://libxlsxwriter.github.io/](http://libxl
 
 Helper Methods:
 
-* `FastExcel.open(filename = nil, constant_memory: false, default_format: {})` - open new workbook, if `filename` is nil - it will craete tmp file, `default_format` will be called with `workbook.default_format.set(...)`
+* `FastExcel.open(filename = nil, constant_memory: false, default_format: {})` - open new workbook, if `filename` is nil - it will create tmp file, `default_format` will be called with `workbook.default_format.set(...)`
 * `FastExcel.date_num(time, offset = nil)` - generate Excel's internal date value, number of days since 1900-Jan-01, works faster then creating `Libxlsxwriter::Datetime` struct. `offset` argument is number hours from UTC, e.g. `3.5`
 * `FastExcel.print_ffi_obj(object)` - print FFI object fields, just for debugging
 * `workbook.bold_cell_format` - shortcut for creating bold format

--- a/lib/fast_excel.rb
+++ b/lib/fast_excel.rb
@@ -397,8 +397,8 @@ module FastExcel
 
       if value.is_a?(Numeric)
         write_number(row_number, cell_number, value, format)
-      elsif defined?(DateTime) && value.is_a?(DateTime)
-        write_datetime(row_number, cell_number, FastExcel.lxw_datetime(value), format)
+      elsif defined?(Date) && value.is_a?(Date)
+        write_datetime(row_number, cell_number, FastExcel.lxw_datetime(value.to_datetime), format)
       elsif value.is_a?(Time)
         write_datetime(row_number, cell_number, FastExcel.lxw_time(value), format)
       elsif value.is_a?(Formula)

--- a/test/date_test.rb
+++ b/test/date_test.rb
@@ -20,3 +20,37 @@ describe "FastExcel.date_num" do
   end
 
 end
+
+describe "FastExcel.write_value" do
+
+  it "should save correct datetime" do
+    workbook = FastExcel.open(constant_memory: true)
+    worksheet = workbook.add_worksheet
+
+    format = workbook.number_format("yyyy-mm-dd hh:mm:ss")
+    value = DateTime.parse('2017-03-01 15:15:15 +0000')
+
+    worksheet.write_value(0, 0, value, format)
+    workbook.close
+
+    data = parse_xlsx_as_matrix(workbook.filename)
+
+    assert_equal(data[0][0], value)
+  end
+
+  it "should save correct date" do
+    workbook = FastExcel.open(constant_memory: true)
+    worksheet = workbook.add_worksheet
+
+    format = workbook.number_format("yyyy-mm-dd")
+    value = Date.parse('2017-03-01')
+
+    worksheet.write_value(0, 0, value, format)
+    workbook.close
+
+    data = parse_xlsx_as_matrix(workbook.filename)
+
+    assert_equal(data[0][0], value)
+  end
+
+end


### PR DESCRIPTION
Since `DateTime` is a subclass of `Date` we can check if the value is
a `Date` and call `to_datetime` to either get `self` or a `Date`
converted to a `DateTime`.