### PR TITLE
Allow to open with an empty existing file

### DIFF
--- a/lib/fast_excel.rb
+++ b/lib/fast_excel.rb
@@ -25,7 +25,7 @@ module FastExcel
   def self.open(filename = nil, constant_memory: false, default_format: nil)
     tmp_file = false
     if filename
-      if File.exist?(filename)
+      if File.exist?(filename) && File.size(filename) > 0
         raise ArgumentError, "File '#{filename}' already exists. FastExcel can not open existing files, only create new files"
       end
     else


### PR DESCRIPTION
As discussed [here](https://github.com/Paxa/fast_excel/commit/1baed0a6b2134f803bead4d4ffa198f0646dcde4), it would be a better UX to allow the user to provide their own managed tempfile for FastExcel to write to. 