### PR TITLE
Cleanup tmp folder too

### DIFF
--- a/lib/fast_excel.rb
+++ b/lib/fast_excel.rb
@@ -394,10 +394,7 @@ module FastExcel
     end
 
     def remove_tmp_folder
-      if tmp_file
-        File.delete(filename)
-        FileUtils.remove_entry(File.dirname(filename))
-      end
+      FileUtils.remove_entry(File.dirname(filename)) if tmp_file
     end
 
     def constant_memory?

--- a/lib/fast_excel.rb
+++ b/lib/fast_excel.rb
@@ -390,11 +390,14 @@ module FastExcel
       close if @is_open
       File.open(filename, 'rb', &:read)
     ensure
-      remove_tmp_file
+      remove_tmp_folder
     end
 
-    def remove_tmp_file
-      File.delete(filename) if tmp_file
+    def remove_tmp_folder
+      if tmp_file
+        File.delete(filename)
+        FileUtils.remove_entry(File.dirname(filename))
+      end
     end
 
     def constant_memory?

--- a/test/tmpfile_test.rb
+++ b/test/tmpfile_test.rb
@@ -17,6 +17,7 @@ describe "FastExcel" do
     workbook.read_string
 
     refute(File.exist?(workbook.filename))
+    refute(File.exist?(File.dirname(workbook.filename)))
     refute(workbook.is_open)
   end
 


### PR DESCRIPTION
This gem seems to be leaking tmp folders.
Ideally `FastExcel.open` method should force a block to be  received and cleanup the folder at the end, but this patch should be enough.