### PR TITLE
Fix crash when sheet name exceeds maximum length

### DIFF
--- a/lib/fast_excel.rb
+++ b/lib/fast_excel.rb
@@ -362,8 +362,12 @@ module FastExcel
     end
 
     def add_worksheet(sheetname = nil)
-      if !sheetname.nil? && @sheet_names.include?(sheetname)
-        raise ArgumentError, "Worksheet name '#{sheetname}' is already in use"
+      if !sheetname.nil?
+        if sheetname.length > Libxlsxwriter::SHEETNAME_MAX
+          raise ArgumentError, "Worksheet name '#{sheetname}' exceeds Excel's limit of #{Libxlsxwriter::SHEETNAME_MAX} characters"
+        elsif @sheet_names.include?(sheetname)
+          raise ArgumentError, "Worksheet name '#{sheetname}' is already in use"
+        end
       end
 
       sheet = super(sheetname)

--- a/test/validations_test.rb
+++ b/test/validations_test.rb
@@ -24,4 +24,24 @@ describe "FastExcel validations" do
     assert_equal("Sheet1", ws1[:name])
     assert_equal("Sheet2", ws2[:name])
   end
+
+  it "should raise error when the sheet name exceeds maximum length" do
+    workbook = FastExcel.open(constant_memory: true)
+
+    error = assert_raises do
+      workbook.add_worksheet("ABCDEFGHIJKLMNOPQRSTUVWXYZ012345")
+    end
+
+    assert_equal(ArgumentError, error.class)
+    assert_equal("Worksheet name 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012345' exceeds Excel's limit of 31 characters", error.message)
+  end
+
+  it "should not raise error when the sheet name is at maximum length" do
+    workbook = FastExcel.open(constant_memory: true)
+
+    worksheet = workbook.add_worksheet("ABCDEFGHIJKLMNOPQRSTUVWXYZ01234")
+    worksheet.append_row(["aaa", "bbb", "ccc"])
+
+    assert_equal("ABCDEFGHIJKLMNOPQRSTUVWXYZ01234", worksheet[:name])
+  end
 end


### PR DESCRIPTION
If you add a worksheet with a name that exceeds the maximum character limit (31 characters), then FastExcel segfaults the next time you try to append data and crashes the running process. A warning is printed to the screen, but that doesn't prevent the process from crashing. Here's a basic example:

```ruby
workbook = FastExcel.open
worksheet = workbook.add_worksheet("ABCDEFGHIJKLMNOPQRSTUVWXYZ012345")
worksheet.append_row(["a"])
```

```
[WARNING]: workbook_add_worksheet(): worksheet name 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012345' has error: Worksheet name exceeds Excel's limit of 31 characters.
lib/fast_excel/binding/worksheet.rb:210: [BUG] Segmentation fault at 0x00000000000000cc
...
```

This pull request fixes the issue by adding validations in the ruby side of things to prevent these long worksheet names from being added. This is similar to how this other worksheet name issue was fixed: https://github.com/Paxa/fast_excel/issues/19 However, I'm not sure if there's maybe better ways to fix this so other errors/warnings libxlsxwriter might generate can be caught and handled (rather than handling these on a case-by-case basis).