### PR TITLE
Fix worksheet.right_to_left option when using pry-rails gem 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### Version 0.3.0 - 18 abr 2020
+
+* [BREAKING CHANGE] Rename `worksheet.right_to_left` to `worksheet.set_right_to_left`:
+  - now it will work properly when using the `pry-rails` gem, not forcing the document start from right even when this method is not called.
+
 #### Version 0.2.6 - 26 jan 2019
 
 * Add column auto width (thanks to @duffyjp)

--- a/fast_excel.gemspec
+++ b/fast_excel.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "fast_excel"
-  s.version     = "0.2.6"
+  s.version     = "0.3.0"
   s.author      = ["Pavel Evstigneev"]
   s.email       = ["pavel.evst@gmail.com"]
   s.homepage    = "https://github.com/paxa/fast_excel"

--- a/lib/fast_excel/binding/worksheet.rb
+++ b/lib/fast_excel/binding/worksheet.rb
@@ -593,7 +593,7 @@ module Libxlsxwriter
     end
   
     # @return [nil] 
-    def right_to_left()
+    def set_right_to_left()
       Libxlsxwriter.worksheet_right_to_left(self)
     end
   

--- a/test/worksheet_test.rb
+++ b/test/worksheet_test.rb
@@ -97,7 +97,7 @@ describe "FastExcel::WorksheetExt append_row" do
     workbook = FastExcel.open(constant_memory: true)
 
     ws = workbook.add_worksheet
-    ws.right_to_left
+    ws.set_right_to_left
     assert_equal(ws[:right_to_left], 1)
 
     ws = workbook.add_worksheet


### PR DESCRIPTION
Rename `worksheet.right_to_left` to `worksheet.set_right_to_left`
- now it will work properly when using the `pry-rails` gem, not forcing the document start from right even when this method is not called.

Fixes: https://github.com/Paxa/fast_excel/issues/46

PS: Breaking change!