### PR TITLE
Fix for ffi library loading issue on Windows (issue #61).

### DIFF
--- a/lib/fast_excel/binding.rb
+++ b/lib/fast_excel/binding.rb
@@ -7,6 +7,8 @@ module Libxlsxwriter
 
   LIB_FILENAME = if RUBY_PLATFORM =~ /darwin/
     "libxlsxwriter.dylib"
+  elsif ['x64-mingw32', 'i386-mingw32'].include? RUBY_PLATFORM
+    "libxlsxwriter.dll"
   else
     "libxlsxwriter.so"
   end


### PR DESCRIPTION
Fixes issue #61. I had to edit the file generated by *ffi_gen* by hand to get this to work.

Without this commit, the following occurs when trying to run the test suite using Ruby 2.6 on Windows (the 64-bit version from [RubyInstaller2](https://github.com/oneclick/rubyinstaller2)

<details>

<summary>Errors when trying to run test suite without this commit.</summary>

```
C:\Users\preet\Projects\OpenSource\fast_excel>bundle exec rake test
ansi: 'gem install win32console' to use color on Windows
Traceback (most recent call last):
        14: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:5:in `<main>'
        13: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:5:in `select'
        12: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:17:in `block in <main>'
        11: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb:17:in `require'
        10: from C:/Users/preet/Projects/OpenSource/fast_excel/test/auto_width_test.rb:1:in `<top (required)>'
         9: from C:/Users/preet/Projects/OpenSource/fast_excel/test/auto_width_test.rb:1:in `require_relative'
         8: from C:/Users/preet/Projects/OpenSource/fast_excel/test/test_helper.rb:15:in `<top (required)>'
         7: from C:/Users/preet/Projects/OpenSource/fast_excel/test/test_helper.rb:15:in `require_relative'
         6: from C:/Users/preet/Projects/OpenSource/fast_excel/lib/fast_excel.rb:1:in `<top (required)>'
         5: from C:/Users/preet/Projects/OpenSource/fast_excel/lib/fast_excel.rb:1:in `require_relative'
         4: from C:/Users/preet/Projects/OpenSource/fast_excel/lib/fast_excel/binding.rb:5:in `<top (required)>'
         3: from C:/Users/preet/Projects/OpenSource/fast_excel/lib/fast_excel/binding.rb:14:in `<module:Libxlsxwriter>'
         2: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/ffi-1.13.1-x64-mingw32/lib/ffi/library.rb:99:in `ffi_lib'
         1: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/ffi-1.13.1-x64-mingw32/lib/ffi/library.rb:99:in `map'
C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/ffi-1.13.1-x64-mingw32/lib/ffi/library.rb:145:in `block in ffi_lib': Could not open library 'C:/Users/preet/Projects/OpenSource/fast_excel/libxlsxwriter/lib/li (LoadError)so': The specified module could not be found.
rake aborted!
Command failed with status (1)

Tasks: TOP => test
(See full trace by running task with --trace)

C:\Users\preet\Projects\OpenSource\fast_excel>

```

</details>

With this commit, the test suite passes:

<details>

<summary>Test suite run with this commit.</summary>

```
C:\Users\preet\Projects\OpenSource\fast_excel>bundle exec rake test
ansi: 'gem install win32console' to use color on Windows

# Running tests with run options --seed 13435:

.......SSS..........................SSSSSSS.............

Finished tests in 0.823494s, 68.0029 tests/s, 99.5757 assertions/s.


Skipped:
FastExcel Calibri text_width#test_0003_should skip system characters [C:/Users/preet/Projects/OpenSource/fast_excel/test/text_width_test.rb:35]:
Use basic width calc for now

Skipped:
FastExcel Calibri text_width#test_0001_should calculate width for character [C:/Users/preet/Projects/OpenSource/fast_excel/test/text_width_test.rb:35]:
Use basic width calc for now

Skipped:
FastExcel Calibri text_width#test_0002_should calculate width with kerning [C:/Users/preet/Projects/OpenSource/fast_excel/test/text_width_test.rb:35]:
Use basic width calc for now

Skipped:
FastExcel Times New Roman text_width#test_0002_should calculate width with kerning [C:/Users/preet/Projects/OpenSource/fast_excel/test/text_width_test.rb:60]:
Use basic width calc for now

Skipped:
FastExcel Times New Roman text_width#test_0001_should calculate width for character [C:/Users/preet/Projects/OpenSource/fast_excel/test/text_width_test.rb:60]:
Use basic width calc for now

Skipped:
FastExcel Times New Roman text_width#test_0003_should skip system characters [C:/Users/preet/Projects/OpenSource/fast_excel/test/text_width_test.rb:60]:
Use basic width calc for now

Skipped:
FastExcel Arial text_width#test_0002_should calculate width with kerning [C:/Users/preet/Projects/OpenSource/fast_excel/test/text_width_test.rb:7]:
Use basic width calc for now

Skipped:
FastExcel Arial text_width#test_0004_should handle multiline text [C:/Users/preet/Projects/OpenSource/fast_excel/test/text_width_test.rb:7]:
Use basic width calc for now

Skipped:
FastExcel Arial text_width#test_0001_should calculate width for character [C:/Users/preet/Projects/OpenSource/fast_excel/test/text_width_test.rb:7]:
Use basic width calc for now

Skipped:
FastExcel Arial text_width#test_0003_should skip system characters [C:/Users/preet/Projects/OpenSource/fast_excel/test/text_width_test.rb:7]:
Use basic width calc for now

56 tests, 82 assertions, 0 failures, 0 errors, 10 skips

C:\Users\preet\Projects\OpenSource\fast_excel>
```

</details>