### PR TITLE
Prepare for ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,20 @@ matrix:
       - ls -lah /Applications
       - sudo xcode-select -s /Applications/Xcode-10.2.1.app/Contents/Developer
       - clang --version
+  - os: linux
+    rvm: 2.7.2
+    env: BUILD_DOCKER=true
+    services:
+      - docker
+  - os: linux
+    rvm: 3.0.0-rc1
+    env: BUILD_DOCKER=true
+    services:
+      - docker
   fast_finish: true
 
 before_install:
-  - gem install bundler -v 2.0.2
+  - gem install bundler -v 2.2.2
 
 script:
   - bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,15 +33,11 @@ matrix:
       - clang --version
   - os: linux
     rvm: 2.7.2
-    env: BUILD_DOCKER=true
-    services:
-      - docker
   - os: linux
-    rvm: 3.0.0-rc1
-    env: BUILD_DOCKER=true
-    services:
-      - docker
+    rvm: 3.0.0-preview2
   fast_finish: true
+  allow_failures:
+    - rvm: 3.0.0-preview2
 
 before_install:
   - gem install bundler -v 2.2.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
     htmlentities (4.3.4)
     mimemagic (0.3.5)
     mini_portile2 (2.4.0)
-    minitest (5.14.1)
+    minitest (5.14.2)
     minitest-reporters (1.4.2)
       ansi
       builder
@@ -57,6 +57,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   axlsx!
@@ -72,4 +73,4 @@ DEPENDENCIES
   xlsxtream
 
 BUNDLED WITH
-   2.0.2
+   2.2.2

--- a/fast_excel.gemspec
+++ b/fast_excel.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Ultra Fast Excel Writer}
   s.description = "Wrapper for libxlsxwriter using ffi"
   s.license     = 'MIT'
-  s.required_ruby_version = '~> 2.0'
+  s.required_ruby_version = '~> 3.0'
 
   s.files       = `git ls-files`.split("\n")
   s.test_files  = []

--- a/fast_excel.gemspec
+++ b/fast_excel.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Ultra Fast Excel Writer}
   s.description = "Wrapper for libxlsxwriter using ffi"
   s.license     = 'MIT'
-  s.required_ruby_version = '~> 3.0'
+  s.required_ruby_version = '>= 2.0'
 
   s.files       = `git ls-files`.split("\n")
   s.test_files  = []

--- a/fast_excel.gemspec
+++ b/fast_excel.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Ultra Fast Excel Writer}
   s.description = "Wrapper for libxlsxwriter using ffi"
   s.license     = 'MIT'
-  s.required_ruby_version = '>= 2.0'
+  s.required_ruby_version = ['>= 2.0', '< 4.0']
 
   s.files       = `git ls-files`.split("\n")
   s.test_files  = []


### PR DESCRIPTION
Ruby 3.0 is going to be released on 25th of December, therefore preparing for it sounds like a good idea to me.

Also another question, it is a common best practice to not check in `Gemfile.lock` to version control for rubygems, should I add it to `.gitignore`?