### PR TITLE
Create alias for 'remove_tmp_folder' method to align with docs

### DIFF
--- a/lib/fast_excel.rb
+++ b/lib/fast_excel.rb
@@ -401,6 +401,8 @@ module FastExcel
       FileUtils.remove_entry(File.dirname(filename)) if tmp_file
     end
 
+    alias_method :remove_tmp_file, :remove_tmp_folder
+
     def constant_memory?
       #FastExcel.print_ffi_obj(self[:options])
       @constant_memory ||= self[:options][:constant_memory] != 0

--- a/test/tmpfile_test.rb
+++ b/test/tmpfile_test.rb
@@ -21,4 +21,11 @@ describe "FastExcel" do
     refute(workbook.is_open)
   end
 
+  it "should delete tmp file after 'remove_tmp_file' method is called" do
+      workbook = FastExcel.open
+
+      assert(File.exist?(workbook.filename))
+      workbook.remove_tmp_file
+      refute(File.exist?(workbook.filename))
+  end
 end


### PR DESCRIPTION
First PR on a non-work project, may have totally screwed this up =P

I noticed the README.md calls out that we should be able to delete a file using 'remove_tmp_file' but in practice, that method does not exist. Looking through the FastExcell class it appears we really need to use, 'remove_tmp_folder'

The safest, simplest approach in my mind (aside from changing the documentation) would be to create an alias. Please note, I added a test, but kept getting an error trying to run them so I'm hoping a CI/CD operation will double check this fairly simple test.

Open to any/all feedback, like I said... First time trying to work with an open source project.