### PR TITLE
Get utc_offset from current value if possible

### DIFF
--- a/lib/fast_excel.rb
+++ b/lib/fast_excel.rb
@@ -91,8 +91,11 @@ module FastExcel
   # https://support.microsoft.com/en-us/help/214330/differences-between-the-1900-and-the-1904-date-system-in-excel
   def self.date_num(time, offset = nil)
     unless offset
-      # Try use Rails' app timezone
-      if Time.respond_to?(:zone)
+      # Try use value utc_offset
+      if time.respond_to?(:utc_offset)
+        offset = time.utc_offset
+      # Else try use Rails' app timezone
+      elsif Time.respond_to?(:zone)
         offset = Time.zone.utc_offset
       else
         offset = 0 # rollback to UTC


### PR DESCRIPTION
Hello,

First of all, thank you very much for this gem!

We are using Rails and generating lots of Excels with differents DateTime attributes. Our problem is that, if we don't specify an offset manually, it will not respect the time offset.

For example, it's missing one hour when generating an Excel with a datetime like this "Sun, 24 Oct 2021 11:00:00 CEST +02:00". Because of daylight saving, timezone was CEST +2 but our current timezone is now CET +1, so we can't just use Time.zone.utc_offset.

I don't know if it's the right approach to fix it but you get the idea :)

Thank you very much for your feedback!

