### PR TITLE
Fix compilation of minizip on NixOS

### DIFF
--- a/libxlsxwriter/third_party/minizip/Makefile
+++ b/libxlsxwriter/third_party/minizip/Makefile
@@ -46,4 +46,4 @@ all: ioapi.o zip.o  ioapi.so zip.so
 	$(Q)$(CC) $(FPIC) -c $(CFLAGS) $< -o $@
 
 clean:
-	$(Q)/bin/rm -f *.o *.so
+	$(Q)rm -f *.o *.so

--- a/libxlsxwriter/third_party/minizip/README.txt
+++ b/libxlsxwriter/third_party/minizip/README.txt
@@ -3,3 +3,6 @@ contrib/minizip/ directory of zlib-1.2.8.
 
 The files zip.h and ioapi.h have had a small number of comments modifed from
 C++ to C style to avoid warnings with -pedantic -ansi.
+
+In addition, the Makefile has been changed to not assume rm(1) is installed at
+/bin/rm, mainly for NixOS and similar systems.

--- a/libxlsxwriter/third_party/tmpfileplus/Makefile
+++ b/libxlsxwriter/third_party/tmpfileplus/Makefile
@@ -39,4 +39,4 @@ all: tmpfileplus.o tmpfileplus.so
 	$(Q)$(CC) $(FPIC) -c $(CFLAGS) $< -o $@
 
 clean:
-	$(Q)/bin/rm -f *.o *.so
+	$(Q)rm -f *.o *.so


### PR DESCRIPTION
NixOS does not have `/bin/rm`, and assuming this path to the binary is not portable. Changed the third-party Makefiles to check for `rm` the same way as the project Makefile; i.e. by using `PATH`.

This fixes compilation on NixOS, and possibly other systems with isolated packages.