### PR TITLE
auto-width: On close set empty columns to default width

### DIFF
--- a/lib/fast_excel.rb
+++ b/lib/fast_excel.rb
@@ -541,7 +541,7 @@ module FastExcel
 
     def close
       if auto_width?
-        @column_widths.each do |num, width|
+        @column_widths.transform_values!{ |width| width || DEF_COL_WIDTH }.each do |num, width|
           set_column_width(num, width + 0.2)
         end
       end

--- a/test/auto_width_test.rb
+++ b/test/auto_width_test.rb
@@ -16,4 +16,24 @@ describe "FastExcel text_width" do
 
     assert_equal(sheet.calculated_column_widths, {0 => 3.52, 1 => 5.28, 2 => 14.96, 3 => 44.88})
   end
+
+  it "should set the default column width for an empty column on close" do
+    workbook = FastExcel.open(constant_memory: false)
+    sheet = workbook.add_worksheet
+    sheet.auto_width = true
+
+    sheet.append_row([
+      nil,
+      "tini",
+      "Longer",
+      "Some longer text!",
+      "This gem is FFI binding for libxlsxwriter C library"
+    ])
+
+    assert_equal(sheet.calculated_column_widths, {0 => nil, 1 => 3.52, 2 => 5.28, 3 => 14.96, 4 => 44.88})
+
+    workbook.close
+
+    assert_equal(sheet.calculated_column_widths, {0 => FastExcel::DEF_COL_WIDTH, 1 => 3.52, 2 => 5.28, 3 => 14.96, 4 => 44.88})
+  end
 end


### PR DESCRIPTION
When auto-width is enabled, having an empty column (e.g. a column width only `nil` or `''` values) causes `NoMethodError: undefined method '+' for nil:NilClass` because the corresponding value in `@column_widths` ends up as `nil`. This PR adds a test-case that fails on that condition, and also fixes the problem that causes the error. The fix works by replacing `nil` or `0` with the default column width like is also done [here](https://github.com/Paxa/fast_excel/blame/master/lib/fast_excel.rb#L520). To be able to test it and to allow and consuming code to access the final column width, I decided to use `transform_values!` so the final changes are reflected in `@column_widths` and as such in `sheet.calculated_column_widths`, even though the workbook is already closed.

I considered a fix [here](https://github.com/Paxa/fast_excel/blame/master/lib/fast_excel.rb#L499) by replacing `>` with `>=` to allow the resulting value to become `0`, however this would not work because of the [`+ 0.2`](https://github.com/Paxa/fast_excel/blame/master/lib/fast_excel.rb#L545). That `+ 0.2` is also not reflected in the final `@column_widths`, however that was already not the case with the way the test(s) work, so I figured this would be the most intuitive way to fix the implementation while still allowing a simple test.